### PR TITLE
Tuned default lambda memory requirement down to 128 after monitoring …

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -67,6 +67,8 @@ functions:
     handler: lambda.handler
     events: ${file(${opt:envdir, '.'}/${opt:stage, self:provider.stage}-vars.yml):events}
     description: "ETL's synoptics weather station data into the nics datafeeds db."
+    memorySize: 128 # optional, in MB, default is 1024
+    timeout: 10 # optional, in seconds, default is 6
 #    events:  # 1
 #          - http:  # 2
 #              method: get  # 3


### PR DESCRIPTION
…it for a while. Uses ~85MB on average.

Tuned default timeout up to 10 seconds since their were a few timeouts occurring from network/server conditions slowing down the extract.