### PR TITLE
Tuned default lambda memory requirement up to 512MB after monitoring …

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -67,7 +67,7 @@ functions:
     handler: lambda.handler
     events: ${file(${opt:envdir, '.'}/${opt:stage, self:provider.stage}-vars.yml):events}
     description: "ETL's synoptics weather station data into the nics datafeeds db."
-    memorySize: 128 # optional, in MB, default is 1024
+    memorySize: 512 # 512 appears to be optimal for the synoptics processor. Any less and duration creeps up.
     timeout: 10 # optional, in seconds, default is 6
 #    events:  # 1
 #          - http:  # 2


### PR DESCRIPTION
…showed runtimes (duration) creeping up too far.